### PR TITLE
Display traps on device screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ secrets/*
 
 # internal tooling hooks
 dynatrace-internal
+
+# IDE
+.idea/

--- a/src/extension.yaml
+++ b/src/extension.yaml
@@ -1,6 +1,6 @@
 name: com.dynatrace.extension.snmp-generic-device
-version: 1.5.0
-minDynatraceVersion: "1.238"
+version: 1.6.0
+minDynatraceVersion: "1.251"
 author:
   name: Dynatrace
 
@@ -76,14 +76,14 @@ metrics:
       unit: Count
   - key: com.dynatrace.extension.snmp-generic-device.sys.uptime
     metadata:
-      displayName: Time since the last re-start 
+      displayName: Time since the last re-start
       description: The time (in hundredths of a second) since the network management portion of the system was last re-initialized
       unit: Unspecified
   - key: func:com.dynatrace.extension.snmp-generic-device.sys.uptime.millis
     query:
       metricSelector: '(com.dynatrace.extension.snmp-generic-device.sys.uptime) * (10)'
     metadata:
-      displayName: Time since the last re-start 
+      displayName: Time since the last re-start
       description: The time (in milliseconds) since the network management portion of the system was last re-initialized
       unit: MilliSecond
   - key: com.dynatrace.extension.snmp-generic-device.if.lastchange
@@ -211,7 +211,7 @@ metrics:
     metadata:
       displayName: Overall traffic TCP & UDP elements
       description: Total number of TCP segments and UDP datagrams sent + received
-      unit: Count    
+      unit: Count
   - key: com.dynatrace.extension.snmp-generic-device.if.highspeed
     metadata:
       displayName: Interface speed
@@ -322,7 +322,6 @@ snmp:
           - key: com.dynatrace.extension.snmp-generic-device.snmp.out.traps.count
             value: oid:1.3.6.1.2.1.11.29.0
             type: count
-          
 
       - subgroup: NIC status
         featureSet: Interfaces
@@ -348,7 +347,7 @@ snmp:
             value: oid:1.3.6.1.2.1.2.2.1.8
             filter: var:if_oper_status
           - key: if.promiscuousmode  # True if this interface accepts all packets/frames false if only accepts packets/frames addressed to this station
-            value: oid:1.3.6.1.2.1.31.1.1.1.16   
+            value: oid:1.3.6.1.2.1.31.1.1.1.16
         metrics:
           - key: com.dynatrace.extension.snmp-generic-device.if.lastchange
             value: oid:1.3.6.1.2.1.2.2.1.9
@@ -434,7 +433,7 @@ dashboards:
 alerts:
   - path: "alerts/inbound_bandwidth_alert.json"
   - path: "alerts/outbound_bandwidth_alert.json"
-  
+
 topology:
   types:
     - name: snmp:com_dynatrace_extension_snmp_generic_device
@@ -475,6 +474,16 @@ topology:
           displayName: Network Interface Count
         requiredDimensions: []
         instanceNamePattern: Network device {sys.name} @ {device.address}:{device.port}
+      - idPattern: snmp_generic_device_{device.address}
+        sources:
+          - sourceType: Logs
+        attributes:
+          - pattern: '{device.address}'
+            key: dt.ip_addresses
+            displayName: Device Address
+        requiredDimensions:
+          - key: log.source
+            valuePattern: '$eq(snmptraps)'
 
     - name: snmp:com_dynatrace_extension_snmp_generic_device_interface
       displayName: Generic SNMP Device Network Interface
@@ -523,8 +532,27 @@ topology:
       sources:
       - sourceType: Metrics
         condition: $prefix(com.dynatrace.extension.snmp-generic-device)
-
+    - typeOfRelation: SAME_AS
+      fromType: snmp:com_dynatrace_extension_snmp_generic_device
+      toType: snmptraps:com_dynatrace_ext_snmp-traps
+      enabled: true
+      sources:
+      - sourceType: Logs
 screens:
+  - entityType: snmptraps:com_dynatrace_ext_snmp-traps
+    detailsInjections:
+      - type: MESSAGE
+        key: related-generic-entity
+        width: FULL_SIZE
+        conditions:
+          - relatedEntity|entitySelectorTemplate=type(snmp:com_dynatrace_extension_snmp_generic_device),fromRelationships.isSameAs($(entityConditions))
+    messageCards:
+      - key: related-generic-entity
+        type: MESSAGE
+        message:
+          text: "Jump to related [Generic device](relatedEntityScreen|entitySelectorTemplate=type(snmp:com_dynatrace_extension_snmp_generic_device),fromRelationships.isSameAs($(entityConditions))|name=Generic device)"
+          theme: INFO
+
   - entityType: snmp:com_dynatrace_extension_snmp_generic_device
     propertiesCard:
       properties:
@@ -564,126 +592,213 @@ screens:
             key: "snmp_health"
           - type: "ENTITIES_LIST"
             key: "network_interfaces"
+          - conditions:
+            - "!extensionConfigured|extensionId=com.dynatrace.extension.snmp-traps-generic"
+            key: snmp_traps_info
+            type: MESSAGE
+            width: FULL_SIZE
+          - type: "CHART_GROUP"
+            key: traps_stats
+            conditions:
+            - "extensionConfigured|extensionId=com.dynatrace.extension.snmp-traps-generic"
+          - conditions:
+            - "extensionConfigured|extensionId=com.dynatrace.extension.snmp-traps-generic"
+            key: traps_logs
+            type: LOGS
+            width: FULL_SIZE
+    messageCards:
+      - key: snmp_traps_info
+        type: MESSAGE
+        message:
+          text: "Set up [SNMP Traps](hubExtension|extensionId=com.dynatrace.extension.snmp-traps-generic|text=SNMP Traps) extension to improve observability of this device"
+          theme: INFO
+    logsCards:
+    - displayName: Traps and logs
+      enablePaging: true
+      filterQuery: dt.source_entity inEntitySelector "$(entityConditions)"
+      key: traps_logs
+      pageSize: 10
+      showFiltering: true
     chartsCards:
+      - key: traps_stats
+        entitySelectorTemplate: type(snmptraps:com_dynatrace_ext_snmp-traps),toRelationships.isSameAs($(entityConditions))
+        charts:
+        - conditions: []
+          displayName: Traps Count
+          graphChartConfig:
+            metrics:
+              - metricSelector: com.dynatrace.extension.snmp-traps-generic.traps.count:splitBy()
+                visualization:
+                  displayName: Traps count
+                  seriesType: COLUMN
+            yAxes: []
+          visualizationType: GRAPH_CHART
+        - conditions: []
+          displayName: Trap OIDs
+          graphChartConfig:
+            metrics:
+              - metricSelector: com.dynatrace.extension.snmp-traps-generic.traps.count:splitBy("trapoid")
+                visualization:
+                  seriesType: COLUMN
+            stacked: true
+            yAxes: []
+          visualizationType: GRAPH_CHART
+        conditions: []
+        displayName: Traps Statistics
+        numberOfVisibleCharts: 2
       - key: "snmp_health"
         displayName: "SNMP Statistics"
         numberOfVisibleCharts: 4
         charts:
           - displayName: "Request Problems"
-            visualization:
-              themeColor: DEFAULT
-              seriesType: AREA
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.snmp.silentdrops.count"
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.in.bad.versions.count"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.snmp.silentdrops.count"
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.in.bad.versions.count"
+              visualization:
+                themeColor: DEFAULT
+                seriesType: AREA
           - displayName: "SNMP Messages"
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.snmp.in.pkts.count"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.snmp.in.pkts.count"
           - displayName: "PDU Problems"
-            visualization:
-              themeColor: DEFAULT
-              seriesType: COLUMN
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.in.bad.values.count"
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.in.nosuchnames.count"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: DEFAULT
+                seriesType: COLUMN
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.in.bad.values.count"
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.in.nosuchnames.count"
           - displayName: "Community Problems"
-            visualization:
-              themeColor: DEFAULT
-              seriesType: AREA
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.in.bad.community.uses.count"
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.in.bad.community.names.count"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: DEFAULT
+                seriesType: AREA
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.in.bad.community.uses.count"
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.in.bad.community.names.count"
       - key: "network_stats"
         displayName: "Network Statistics"
         numberOfVisibleCharts: 8
         charts:
           - displayName: "Network Interfaces Traffic"
-            visualization:  
-              themeColor: ROYALBLUE
-              seriesType: LINE
-            metrics:
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: ROYALBLUE
+                seriesType: LINE
+              metrics:
                 - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.out.octets.bitpersec:splitBy()"
                 - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.in.octets.bitpersec:splitBy()"
           - displayName: "Bandwidth Utilization In & Out"
-            visualization:
-              themeColor: ROYALBLUE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.in.bandwidth:splitBy()"
-              - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.out.bandwidth:splitBy()"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: ROYALBLUE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.in.bandwidth:splitBy()"
+                - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.out.bandwidth:splitBy()"
           - displayName: "Retransmited & Resets"
-            visualization:
-              themeColor: PURPLE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.retrans.segs.count"
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.out.rsts.count"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: PURPLE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.retrans.segs.count"
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.out.rsts.count"
           - displayName: "Errors"
-            visualization:
-              themeColor: PURPLE
-              seriesType: COLUMN
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.in.errs.count"
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.udp.in.errors.count"
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.udp.noports.count"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: PURPLE
+                seriesType: COLUMN
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.in.errs.count"
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.udp.in.errors.count"
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.udp.noports.count"
           - displayName: "TCP traffic"
-            visualization:
-              themeColor: ROYALBLUE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.hc.in.segs.count"
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.hc.out.segs.count"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: ROYALBLUE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.hc.in.segs.count"
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.hc.out.segs.count"
           - displayName: "UDP Traffic"
-            visualization:
-              themeColor: ROYALBLUE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.udp.hc.in.datagrams.count"
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.udp.hc.out.datagrams.count"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: ROYALBLUE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.udp.hc.in.datagrams.count"
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.udp.hc.out.datagrams.count"
           - displayName: "Estabilished Connections"
-            visualization:
-              themeColor: ROYALBLUE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.curr.estab"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: ROYALBLUE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.curr.estab"
           - displayName: "Transitions Open"
-            visualization:
-              themeColor: ROYALBLUE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.activeopens.count"
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.passiveopens.count"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: ROYALBLUE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.activeopens.count"
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.passiveopens.count"
           - displayName: "Transitions Closed"
-            visualization:
-              themeColor: PURPLE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.estab.resets.count"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: PURPLE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "com.dynatrace.extension.snmp-generic-device.tcp.estab.resets.count"
           - displayName: "Overall TCP & UDP Traffic"
-            visualization:
-              themeColor: ROYALBLUE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.totaltraffic"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: ROYALBLUE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.totaltraffic"
           - displayName: "Overall TCP Traffic"
-            visualization:
-              themeColor: ROYALBLUE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.tcp.hc.total"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: ROYALBLUE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.tcp.hc.total"
           - displayName: "Overall UDP Traffic"
-            visualization:
-              themeColor: ROYALBLUE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.udp.hc.total"
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: ROYALBLUE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.udp.hc.total"
           - displayName: "Interfaces overall Bandwidth Utilization"
-            visualization:
-              themeColor: ROYALBLUE
-              seriesType: LINE
-            metrics:
-              - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.bandwidth:splitBy()"
-          
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              visualization:
+                themeColor: ROYALBLUE
+                seriesType: LINE
+              metrics:
+                - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.bandwidth:splitBy()"
+
     entitiesListCards:
       - key: "network_interfaces"
         displayName: "Network Interfaces"
@@ -692,27 +807,31 @@ screens:
         displayCharts: true
         enableDetailsExpandability: true
         numberOfVisibleCharts: 2
-        charts: 
+        charts:
         - displayName: "Traffic"
-          metrics: 
-          - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.in.octets.bitpersec"
-          - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.out.octets.bitpersec"
+          visualizationType: GRAPH_CHART
+          graphChartConfig:
+            metrics:
+            - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.in.octets.bitpersec"
+            - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.out.octets.bitpersec"
         - displayName: "Bandwidth"
-          metrics: 
-          - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.in.bandwidth"
-          - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.out.bandwidth"
+          visualizationType: GRAPH_CHART
+          graphChartConfig:
+            metrics:
+            - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.in.bandwidth"
+            - metricSelector: "func:com.dynatrace.extension.snmp-generic-device.if.out.bandwidth"
         displayIcons: true
-        columns: 
+        columns:
         - type: ATTRIBUTE
-          attribute: 
+          attribute:
             key: "highspeed"
             displayName: "IF speed (Mbps)"
         - type: ATTRIBUTE
-          attribute: 
+          attribute:
             key: "type"
             displayName: "IF type"
         - type: ATTRIBUTE
-          attribute: 
+          attribute:
             key: "opStatus"
             displayName: "Operational status"
         filtering:
@@ -764,25 +883,33 @@ screens:
         numberOfVisibleCharts: 2
         charts:
           - displayName: Traffic
-            metrics:
-            - metricSelector: func:com.dynatrace.extension.snmp-generic-device.if.out.octets.bitpersec
-            - metricSelector: func:com.dynatrace.extension.snmp-generic-device.if.in.octets.bitpersec       
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              metrics:
+              - metricSelector: func:com.dynatrace.extension.snmp-generic-device.if.out.octets.bitpersec
+              - metricSelector: func:com.dynatrace.extension.snmp-generic-device.if.in.octets.bitpersec
           - displayName: Bandwidth utilization
-            metrics:
-            - metricSelector: func:com.dynatrace.extension.snmp-generic-device.if.out.bandwidth
-            - metricSelector: func:com.dynatrace.extension.snmp-generic-device.if.in.bandwidth
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              metrics:
+              - metricSelector: func:com.dynatrace.extension.snmp-generic-device.if.out.bandwidth
+              - metricSelector: func:com.dynatrace.extension.snmp-generic-device.if.in.bandwidth
       - key: other
-        displayName: Errors and discards  
-        numberOfVisibleCharts: 2  
+        displayName: Errors and discards
+        numberOfVisibleCharts: 2
         charts:
           - displayName: Errors
-            metrics:
-            - metricSelector: com.dynatrace.extension.snmp-generic-device.if.out.errors.count
-            - metricSelector: com.dynatrace.extension.snmp-generic-device.if.in.errors.count
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              metrics:
+              - metricSelector: com.dynatrace.extension.snmp-generic-device.if.out.errors.count
+              - metricSelector: com.dynatrace.extension.snmp-generic-device.if.in.errors.count
           - displayName: Discards
-            metrics:
-            - metricSelector: com.dynatrace.extension.snmp-generic-device.if.out.discards.count
-            - metricSelector: com.dynatrace.extension.snmp-generic-device.if.in.discards.count        
+            visualizationType: GRAPH_CHART
+            graphChartConfig:
+              metrics:
+              - metricSelector: com.dynatrace.extension.snmp-generic-device.if.out.discards.count
+              - metricSelector: com.dynatrace.extension.snmp-generic-device.if.in.discards.count
     propertiesCard:
       displayOnlyConfigured: false
       properties:
@@ -796,7 +923,7 @@ screens:
           displayName: Speed
           hidden: true
       - type: ATTRIBUTE
-        attribute: 
+        attribute:
           key: highspeed
           displayName: Speed (Mbps)
-          unit: MegaBitPerSecond  
+          unit: MegaBitPerSecond


### PR DESCRIPTION
- update of screen definition to fit schema v.251
- define traps - generic device relationship
- traps section added
- add traps stats chart group on the generic device screen
- add a link to traps config in case traps extension is not configured
- define injection to traps screen